### PR TITLE
don't do `using Distributions` outside the top level module

### DIFF
--- a/src/Changepoints.jl
+++ b/src/Changepoints.jl
@@ -1,5 +1,3 @@
-using Distributions
-
 module Changepoints
 
 using Distributions


### PR DESCRIPTION
that brings in Distributions' exports into global scope for all
users of changepoints whether or not they want them
